### PR TITLE
renames pomander command to pomander from postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node server/index.js",
-    "postinstall": "curl -s https://raw.githubusercontent.com/campoverde/pomander/master/bin/install | bash",
+    "pomander": "curl -s https://raw.githubusercontent.com/campoverde/pomander/master/bin/install | bash",
     "react-dev": "webpack -d --watch",
     "server-dev": "nodemon server/index.js"
   },


### PR DESCRIPTION
Renaming postinstall in order to not break Heroku build process.